### PR TITLE
Silently ignore futile recompile attempts.

### DIFF
--- a/auto-compile.el
+++ b/auto-compile.el
@@ -762,6 +762,7 @@ file would get loaded."
           (when (setq el (packed-locate-library file nosuffix))
             (setq elc (byte-compile-dest-file el))
             (when (and (file-exists-p elc)
+                       (file-writable-p elc)
                        (file-newer-than-file-p el elc))
               (message "Recompiling %s..." el)
               (packed-byte-compile-file el)


### PR DESCRIPTION
I have an issue with using auto-compile with emacs-snapshot on ubuntu 16.04. 

The problem is that the package for some reason has newer timestamps on their .el.gz files than the elc files.

E.g.

-rw-r--r-- 1 root root 8507 Jul 10 12:23 ./share/emacs/25.1.50/lisp/calc/calc-cplx.elc
-rw-r--r-- 1 root root 2588 Jul 10 12:34 ./share/emacs/25.1.50/lisp/calc/calc-cplx.el.gz

This is of course a bug on their side but it seems like if the output path is not writable there's no reason for auto-compile to attempt to compile.

I'm not sure this actually is the right patch for the issue or not since there's other callers to auto-compile-byte-compile.

I also just realized that I can fix this with an inhibit hook but I figured it's the kind of issue that could trip up others.